### PR TITLE
fix: canvas blur in HiPDI screen

### DIFF
--- a/src/components/musicPlayer.vue
+++ b/src/components/musicPlayer.vue
@@ -90,9 +90,14 @@ export default {
       //part1: 画布
       var canvas = this.$refs.canvas;
       var context = canvas.getContext("2d");
+      
+      // 修复canvas在高分屏下模糊的问题
+      canvas.width = canvas.clientWidth*window.devicePixelRatio;
+      canvas.height = canvas.clientHeight*window.devicePixelRatio;
+      context.setTransform(window.devicePixelRatio,0,0,window.devicePixelRatio,0,0);
 
-      var WIDTH = canvas.width;
-      var HEIGHT = canvas.height;
+      var WIDTH = canvas.clientWidth;
+      var HEIGHT = canvas.clientHeight;
 
       //part2: 音频
       //audio.load();


### PR DESCRIPTION
1. 修复canvas在高分屏下模糊的问题
![原来的效果](https://s2.ax1x.com/2020/02/14/1XZhRK.png)
![后来的效果](https://s2.ax1x.com/2020/02/14/1XeSsg.png)